### PR TITLE
Add support for compression of all status codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.calva/
+.lsp/

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,8 @@
-(defproject amalloy/ring-gzip-middleware "0.1.5-SNAPSHOT"
-  :url "https://github.com/clj-commons/ring-gzip-middleware"
-  :description "Ring gzip encoding middleware"
-  :dependencies [[org.clojure/clojure "1.9.0"]]
-  :profiles {:1.10 {:dependencies [[org.clojure/clojure "1.10.0-RC3"]]}
-             :1.9  {}
-             :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.6  {:dependencies [[org.clojure/clojure "1.6.0"]]}}
-  :deploy-repositories [["releases" :clojars]
-                        ["snapshots" :clojars]]
-  :aliases {"all" ["with-profile" "1.6:1.7:1.8:1.9:1.10"]}
-  :min-lein-version "2.0.0")
+(defproject blackwaterpark/ring-gzip-middleware "1.0.0"
+  :description "Ring gzip encoding middleware (Eva fork)"  
+  :url "https://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "https://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.10.1"]]  
+  :target-path "target/%s"
+  :profiles {:uberjar {:aot :all}})

--- a/test/ring/middleware/gzip_test.clj
+++ b/test/ring/middleware/gzip_test.clj
@@ -104,7 +104,7 @@
     (is (= "text" (encoding resp)))
     (is (= output (:body resp)))))
 
-(deftest test-status
+(deftest test-status-default
   "don't compress non-200 responses"
   (let [app (wrap-gzip (fn [req] {:status 404
                                   :body output
@@ -112,3 +112,17 @@
         resp (app (accepting "gzip"))]
     (is (nil? (encoding resp)))
     (is (= output (:body resp)))))
+
+(deftest test-status-compress-all
+  "compress all status codes when option is true"
+  (are [status-code] (let [app (wrap-gzip (fn [_] {:status status-code
+                                                   :body output
+                                                   :headers {}}) 
+                                          :compress-all-status-codes? true)
+                           res (app (accepting "gzip"))]
+                       (is (= "gzip" (encoding res)) 
+                           (format "Compressing status code %s" status-code)))
+    201
+    400
+    404
+    500))


### PR DESCRIPTION
By default the library only compresses the response body of responses with 200 status codes. This PR adds an option, `:compress-all-status-codes`, which can be set to true to enable compression of response bodies for all status codes.

This PR also contains changes to the project file to support publishing to Clojars.